### PR TITLE
trigger build to fix content security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Deployments to production are done via Jenkins.
 4. In Cloudfront, access the distribution you want to update. In the `Behaviors` tab tick the checkbox next to the `*` `Path Pattern` and click `Edit`.
 5. In the `Edit Behavior` page scroll to the bottom. In the `Lambda Function ARN` text box update the `Lambda version` at the end of the ARN. The `Event Type` should be `Origin Response`
 
-For example, to update the Lambda function below, you would update the trailing `5` to the version from the environemnt's Lambda deloyment job1.
+For example, to update the Lambda function below, you would update the trailing `6` to the version from the environemnt's Lambda deloyment job1.
 
-`arn:aws:lambda:us-east-1:960751427106:function:dev-app-lambda-use1:5`
+`arn:aws:lambda:us-east-1:960751427106:function:dev-app-lambda-use1:6`
 


### PR DESCRIPTION
The semi-colon that concludes a list segment was in the wrong place for `img-src`.
The actual correction in the in the `infrastructure` repo.
This build is necessary to get the `infrastructure` change applied.