### PR TITLE
Fix Lambda permissions

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "lambda_iam_policy_document" {
     effect = "Allow"
 
     actions = [
-      "ssm:GetParameter",
+      "ssm:GetParameters",
     ]
 
     resources = [


### PR DESCRIPTION
Lambda now calls GetParameters instead of GetParameter, so the IAM role should have been updated.