### PR TITLE
Handler Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,26 @@ This Lambda function adds headers to the App's response to a client's request.
 
 __Build and Development Deployment__
 
-Artifacts are built in Jenkins and published to S3. The dev build triggers a deployment of the Lambda function and creates a "Lambda version" that is used by Cloudfront.
+Artifacts are built in Jenkins and published to S3. The dev build triggers a deployment of the Lambda function and
+creates a "Lambda version" that can be used by Cloudfront.
+See steps 4 - 6 below for how to update Cloudfront to use the new version.
 
 __Deployment of an Artifact__
 
 Deployments to production are done via Jenkins.
 
-1. Determine the artifact version you want to deploy (you can find the latest version number in the development deployment job). 
+1. Determine the artifact version you want to deploy (you can find the latest version number in the development
+   deployment job).
 2. Deploy the Lambda function via Jenkins.
 3. Grab the "Lambda version" from output of the Jenkins deployment job.
-4. In Cloudfront, access the distribution you want to update. In the `Behaviors` tab tick the checkbox next to the `*` `Path Pattern` and click `Edit`.
-5. In the `Edit Behavior` page scroll to the bottom. In the `Lambda Function ARN` text box update the `Lambda version` at the end of the ARN. The `Event Type` should be `Origin Response`
+4. In Cloudfront, access the distribution you want to update. In the `Behaviors` tab tick the checkbox next to
+   the `*` `Path Pattern` and click `Edit`.
+5. In the `Edit Behavior` page scroll to the bottom. In the `Lambda Function ARN` text box update the `Lambda version`
+   at the end of the ARN. The `Event Type` should be `Origin Response`
 
-For example, to update the Lambda function below, you would update the trailing `6` to the version from the environemnt's Lambda deloyment job1.
+   For example, to update the Lambda function below, you would update the trailing `6` to the version from the
+   environment's Lambda deployment job.
 
-`arn:aws:lambda:us-east-1:960751427106:function:dev-app-lambda-use1:6`
-
+   `arn:aws:lambda:us-east-1:960751427106:function:dev-app-lambda-use1:6`
+6. In the `Invalidations` page choose `Create invalidation` with path `/*`. This will force Cloudfront to use the new
+   Lambda version.

--- a/source/package.json
+++ b/source/package.json
@@ -8,7 +8,8 @@
     "@aws-sdk/client-ssm": "^3.596.0"
   },
   "devDependencies": {
-    "ava": "^6.1.3"
+    "ava": "^6.1.3",
+    "aws-sdk-client-mock": "^4.0.1"
   },
   "scripts": {
     "test": "./node_modules/.bin/ava ./test/*.spec.js"

--- a/source/test/handler.spec.js
+++ b/source/test/handler.spec.js
@@ -1,0 +1,38 @@
+import test from 'ava';
+import {mockClient} from 'aws-sdk-client-mock';
+import {GetParametersCommand, SSMClient} from "@aws-sdk/client-ssm";
+import {handler, paramNames} from "../app.js";
+
+const ssmMock = mockClient(SSMClient)
+
+test.beforeEach(t => {
+    ssmMock.reset()
+});
+test('handler() test', async t => {
+    const mockParams = paramNames.Names.map(n => {
+        return {Name: n, Value: `policy for ${n}`}
+    })
+    ssmMock.on(GetParametersCommand, paramNames)
+        .resolves({Parameters: mockParams})
+
+    const expectedCSP = mockParams.map(p => p.Value).join(' ')
+
+    const event = {
+        Records: [
+            {
+                cf: {
+                    response: {
+                        headers: {}
+                    }
+                }
+            }
+        ]
+    }
+
+    const modifiedResponse = await handler(event)
+
+
+    t.is(modifiedResponse.headers['referrer-policy'][0].value, "same-origin");
+    t.is(modifiedResponse.headers['content-security-policy'][0].value, expectedCSP);
+
+});


### PR DESCRIPTION
Adds a test of the `handler` which uses a mock for the `SSMClient`.

Updates README to mention the need to update CloudFront for non-prod and also the need to invalidate the CloudFront distribution.
 